### PR TITLE
修复net core 3.0注入到HttpClientFactory时报错

### DIFF
--- a/WebApiClient.Extensions.HttpClientFactory/HttpClientFactoryExtensions.cs
+++ b/WebApiClient.Extensions.HttpClientFactory/HttpClientFactoryExtensions.cs
@@ -55,9 +55,10 @@ namespace WebApiClient.Extensions.HttpClientFactory
                 throw new ArgumentNullException(nameof(configOptions));
             }
 
+            var name = typeof(TInterface).ToString();
             return services
-                .AddHttpClient<TInterface>()
-                .AddTypedClient((httpClient, provider) =>
+                .AddHttpClient(name)
+                .AddTypedClient<TInterface>((httpClient, provider) =>
                 {
                     var httpApiConfig = new HttpApiConfig(httpClient)
                     {


### PR DESCRIPTION
修复net core 3.0注入时报错。
在net core 3.0中[AddTypedClient](https://github.com/aspnet/Extensions/blob/master/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientBuilderExtensions.cs) 添加ReserveClient判断，导致注入时会提示错误。
